### PR TITLE
qemu-img no longer supports a "B" suffix

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -714,7 +714,7 @@ func (d *Driver) generateDiskImage(size int) error {
 		fmt.Printf("ERROR: %s\n", stderr)
 		return err
 	}
-	if stdout, stderr, err := cmdOutErr("qemu-img", "resize", d.diskPath(), fmt.Sprintf("+%dMB", size)); err != nil {
+	if stdout, stderr, err := cmdOutErr("qemu-img", "resize", d.diskPath(), fmt.Sprintf("+%dM", size)); err != nil {
 		fmt.Printf("OUTPUT: %s\n", stdout)
 		fmt.Printf("ERROR: %s\n", stderr)
 		return err


### PR DESCRIPTION
Didn't seem to be doing anything anyway...

Closes #5 